### PR TITLE
Fix bug of i18nMark for rule i18n-mark

### DIFF
--- a/lib/rules/lingui-mark.js
+++ b/lib/rules/lingui-mark.js
@@ -157,6 +157,12 @@ module.exports = {
         }
 
         if (node.parent.type === 'CallExpression' && isLogMessage(node.parent.callee)) {
+          // console.log(`${name}, 你好`)
+          return true;
+        }
+
+        if (node.parent.type === 'CallExpression' && isI18nMethod(node.parent.callee, ['i18nMark'])) {
+          // i18nMark(`${name}, 你好`)
           return true;
         }
 
@@ -164,6 +170,7 @@ module.exports = {
           isI18nMethod(node.parent.tag, ['t']) ||
           isLogMessage(node.parent.callee)
         )) {
+          // i18n.t`${name}, 你好`
           return true;
         }
 

--- a/tests/lib/rules/lingui-mark.js
+++ b/tests/lib/rules/lingui-mark.js
@@ -39,6 +39,9 @@ ruleTester.run('lingui-mark', rule, {
       code: "i18nMark('你好')",
     },
     {
+      code: "i18nMark(`${name}，你好`)",
+    },
+    {
       code: "i18n.plural({ value: count, other: '等#人' })",
     },
     {


### PR DESCRIPTION
```js
i18nMark(`${name}, 你好`)
```

这种会报eslint错，其实是正常的写法，修复了一下